### PR TITLE
Fix $base property PHPDoc type of BVFooter

### DIFF
--- a/BVFooter.php
+++ b/BVFooter.php
@@ -14,7 +14,7 @@ class BVFooter {
    * BVFooter Class Constructor
    *
    * @access public
-   * @param array ($base) - base class parameters
+   * @param object ($base) - base class parameters
    * @param string ($access_method) - access method
    * @param string ($msg) - build message
    * @return object


### PR DESCRIPTION
Phan reports an `PhanTypeExpectedObjectPropAccess` warning because of wrong type for `$base` property:
`Expected an object instance when accessing an instance property, but saw an expression $this->base with type array`.
I would suggest to fix $base property PHPDoc type of BVFooter class.